### PR TITLE
Add configurable LLM choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ pip install -r requirements.txt
   <h2>Step 4: Run the MCP Server</h2>
   <p>In one terminal, start the MCP server:</p>
   <pre>
+# Example using the default open-source model:
+python mcp_server.py
+
+# To use ChatGPT or Claude, set the following environment variables first:
+#   LLM_CHOICE=chatgpt  # or "claude"
+#   OPENAI_API_KEY=your-openai-key      # required for ChatGPT
+#   ANTHROPIC_API_KEY=your-anthropic-key  # required for Claude
 python mcp_server.py
   </pre>
   <p>You should see a message indicating that the server has started (e.g., “Starting MCP server on port 5000...”).</p>
@@ -55,7 +62,7 @@ python mcp_client.py
   <ul>
     <li><strong>Python Version Errors:</strong> Make sure you’re on Python 3.10 or higher.</li>
     <li><strong>Virtual Environment Issues:</strong> Double-check that your environment is activated before installing or running.</li>
-    <li><strong>LLM Loading Problems:</strong> GPT-J 6B is large. Ensure you have sufficient resources. If needed, use a smaller model like GPT-Neo.</li>
+    <li><strong>LLM Loading Problems:</strong> The default CodeLlama model may require significant resources. You can switch models by setting <code>LLM_CHOICE</code> to <code>chatgpt</code> or <code>claude</code> if you have the appropriate API keys.</li>
   </ul>
   
   <hr>

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,34 +1,103 @@
 # mcp_server.py
 
 from mcp.server import McpServer, McpHandler
+import os
 import requests
+import openai
+import anthropic
 from transformers import pipeline
+from typing import List, Dict, Optional, Callable
 
 
-def fetch_repo_files(owner: str, repo: str, path: str = ""):
+def fetch_repo_files(
+    owner: str, repo: str, path: str = "", session: Optional[requests.Session] = None
+) -> List[Dict[str, str]]:
     """Recursively fetch all items in a GitHub repository path."""
+    session = session or requests.Session()
     url = f"https://api.github.com/repos/{owner}/{repo}/contents/{path}"
-    response = requests.get(url)
+    response = session.get(url)
     if response.status_code != 200:
         return []
 
     items = response.json()
-    files = []
+    files: List[Dict[str, str]] = []
     for item in items:
-        if item.get('type') == 'file':
+        if item.get("type") == "file":
             files.append(item)
-        elif item.get('type') == 'dir':
-            files.extend(fetch_repo_files(owner, repo, item.get('path', '')))
+        elif item.get("type") == "dir":
+            files.extend(fetch_repo_files(owner, repo, item.get("path", ""), session))
     return files
 
-# Load an open source LLM for text generation.
-# We use GPT-J 6B; if GPU is available, it will use it; otherwise, it falls back to CPU.
-try:
-    llm = pipeline("text-generation", model="EleutherAI/gpt-j-6B", device=0)
-except Exception as e:
-    # Fallback to CPU if GPU is not available or model load fails.
-    llm = pipeline("text-generation", model="EleutherAI/gpt-j-6B", device=-1)
-print("LLM loaded successfully.")
+
+def fetch_python_files(owner: str, repo: str, session: Optional[requests.Session] = None) -> List[Dict[str, str]]:
+    """Return all Python files in the given repository."""
+    return [
+        item
+        for item in fetch_repo_files(owner, repo, session=session)
+        if item.get("name", "").endswith(".py")
+    ]
+
+
+def aggregate_python_code(
+    files: List[Dict[str, str]], session: Optional[requests.Session] = None
+) -> str:
+    """Download and concatenate the contents of all provided Python files."""
+    session = session or requests.Session()
+    code_parts: List[str] = []
+    for item in files:
+        download_url = item.get("download_url")
+        if not download_url:
+            continue
+        resp = session.get(download_url)
+        if resp.status_code == 200:
+            code_parts.append(f"\n\n# File: {item['path']}\n{resp.text}")
+        else:
+            code_parts.append(
+                f"\n\n# File: {item['path']} - Unable to fetch file content.\n"
+            )
+    return "".join(code_parts)
+
+
+def load_llm(choice: str) -> Callable:
+    """Return a text-generation callable based on the selected LLM."""
+    choice = choice.lower()
+    if choice == "chatgpt":
+        openai.api_key = os.getenv("OPENAI_API_KEY", "")
+
+        def chatgpt(prompt: str, max_length: int = 500, temperature: float = 0.7):
+            resp = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=max_length,
+                temperature=temperature,
+            )
+            return [{"generated_text": resp["choices"][0]["message"]["content"]}]
+
+        return chatgpt
+    if choice == "claude":
+        client = anthropic.Client(os.getenv("ANTHROPIC_API_KEY", ""))
+
+        def claude(prompt: str, max_length: int = 500, temperature: float = 0.7):
+            resp = client.completions.create(
+                model="claude-3-opus-20240229",
+                prompt=f"{anthropic.HUMAN_PROMPT} {prompt}{anthropic.AI_PROMPT}",
+                max_tokens=max_length,
+                temperature=temperature,
+            )
+            return [{"generated_text": resp.completion}]
+
+        return claude
+
+    # Default to a coding-focused open-source model.
+    model_id = "codellama/CodeLlama-7b-hf"
+    try:
+        return pipeline("text-generation", model=model_id, device=0)
+    except Exception:
+        return pipeline("text-generation", model=model_id, device=-1)
+
+
+llm_choice = os.getenv("LLM_CHOICE", "codellama")
+llm = load_llm(llm_choice)
 
 class MyMcpHandler(McpHandler):
     def get_methods(self):
@@ -54,20 +123,14 @@ class MyMcpHandler(McpHandler):
         if not owner or not repo:
             return "Error: Missing 'owner' or 'repo' parameters."
 
-        # Recursively fetch repository contents.
-        contents = fetch_repo_files(owner, repo)
-        if not contents:
-            return "Error: Unable to fetch repository contents."
-        analysis_results = []
-        for item in contents:
-            # Check for Python files for a simple analysis.
-            if item['name'].endswith('.py'):
-                analysis_results.append(
-                    f"File '{item['path']}' might benefit from improved error handling and better comments."
-                )
-        if not analysis_results:
-            analysis_results.append("No Python files found for analysis.")
-        return analysis_results
+        session = requests.Session()
+        py_files = fetch_python_files(owner, repo, session=session)
+        if not py_files:
+            return ["No Python files found for analysis."]
+        return [
+            f"File '{item['path']}' might benefit from improved error handling and better comments."
+            for item in py_files
+        ]
 
     def ask_repo_question(self, params):
         """
@@ -85,22 +148,9 @@ class MyMcpHandler(McpHandler):
         if not owner or not repo or not question:
             return "Error: Missing one or more parameters: 'owner', 'repo', 'question'."
 
-        # Fetch repository contents recursively.
-        contents = fetch_repo_files(owner, repo)
-        if not contents:
-            return "Error: Unable to fetch repository contents."
-        code_aggregate = ""
-        # Iterate through each item to fetch code from Python files.
-        for item in contents:
-            if item['name'].endswith('.py'):
-                download_url = item.get('download_url')
-                if download_url:
-                    file_resp = requests.get(download_url)
-                    if file_resp.status_code == 200:
-                        code_aggregate += f"\n\n# File: {item['path']}\n"
-                        code_aggregate += file_resp.text
-                    else:
-                        code_aggregate += f"\n\n# File: {item['path']} - Unable to fetch file content.\n"
+        session = requests.Session()
+        py_files = fetch_python_files(owner, repo, session=session)
+        code_aggregate = aggregate_python_code(py_files, session=session)
         if not code_aggregate:
             code_aggregate = "No Python files found in the repository."
 
@@ -113,7 +163,7 @@ class MyMcpHandler(McpHandler):
         )
         # Generate an answer using the LLM.
         try:
-            output = llm(prompt, max_length=500, do_sample=True, temperature=0.7)
+            output = llm(prompt, max_length=500, temperature=0.7)
             answer = output[0]['generated_text']
         except Exception as e:
             answer = f"LLM error: {str(e)}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ mcp>=1.5.0         # MCP package (requires Python 3.10+)
 requests>=2.25.0   # For making HTTP requests (e.g., GitHub API calls)
 transformers>=4.0.0  # Hugging Face Transformers library for LLM integration
 torch>=1.7.0       # PyTorch, required by the Transformers library
+openai>=1.0.0      # For ChatGPT API integration
+anthropic>=0.3.0   # For Claude API integration


### PR DESCRIPTION
## Summary
- support multiple LLM backends via new `load_llm` helper
- default to CodeLlama but allow `chatgpt` and `claude` through environment variables
- document how to switch models and added API client deps

## Testing
- `python -m py_compile mcp_client.py mcp_server.py`


------
https://chatgpt.com/codex/tasks/task_e_686def64b8d4832881fa366e83eb3575